### PR TITLE
updates rfw.go to always typecast checkInode()'s result to uint64

### DIFF
--- a/rfw.go
+++ b/rfw.go
@@ -62,7 +62,7 @@ func (l *Writer) Close() error {
 func (l *Writer) checkInode() (uint64, error) {
 	var stat syscall.Stat_t
 	err := syscall.Stat(l.path, &stat)
-	return stat.Ino, err
+	return uint64(stat.Ino), err
 }
 
 func (l *Writer) reopen() error {


### PR DESCRIPTION
On FreeBSD, the syscall 'stat' returns an uint32 which results in this during cross compilation:
github.com/mipearson/rfw/rfw.go:65: cannot use stat.Ino (type uint32) as type uint64 in return argument